### PR TITLE
added GC collect

### DIFF
--- a/plugins/experimental/ts_lua/ts_lua_util.c
+++ b/plugins/experimental/ts_lua/ts_lua_util.c
@@ -187,6 +187,8 @@ ts_lua_add_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n, int a
 
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY */
+	
+	lua_gc(L, LUA_GCCOLLECT, 0);
 
     TSMutexUnlock(arr[i].mutexp);
   }
@@ -227,6 +229,8 @@ ts_lua_del_module(ts_lua_instance_conf *conf, ts_lua_main_ctx *arr, int n)
 
     lua_newtable(L);
     lua_replace(L, LUA_GLOBALSINDEX); /* L[GLOBAL] = EMPTY  */
+	
+	lua_gc(L, LUA_GCCOLLECT, 0);
 
     TSMutexUnlock(arr[i].mutexp);
   }


### PR DESCRIPTION
The Lua memory is not released during ts_lua_add_module and ts_lua_del_module. Refer Jira ticket TS-4266 for more information.